### PR TITLE
Fix for API3.0 - payment_method cannot be accessed directly

### DIFF
--- a/includes/class-wc-cielo-credit-gateway.php
+++ b/includes/class-wc-cielo-credit-gateway.php
@@ -444,7 +444,7 @@ class WC_Cielo_Credit_Gateway extends WC_Cielo_Helper {
 	 * @return array
 	 */
 	public function order_items_payment_details( $items, $order ) {
-		if ( $this->id === $order->payment_method ) {
+		if ( $this->id === $order->get_payment_method() ) {
 			$card_brand   = get_post_meta( $order->id, '_wc_cielo_card_brand', true );
 			$card_brand   = $this->get_payment_method_name( $card_brand );
 			$installments = get_post_meta( $order->id, '_wc_cielo_installments', true );

--- a/includes/class-wc-cielo-debit-gateway.php
+++ b/includes/class-wc-cielo-debit-gateway.php
@@ -354,7 +354,7 @@ class WC_Cielo_Debit_Gateway extends WC_Cielo_Helper {
 	 * @return array
 	 */
 	public function order_items_payment_details( $items, $order ) {
-		if ( $this->id === $order->payment_method ) {
+		if ( $this->id === $order->get_payment_method() ) {
 			$card_brand   = get_post_meta( $order->id, '_wc_cielo_card_brand', true );
 			$card_brand   = $this->get_payment_method_name( $card_brand );
 


### PR DESCRIPTION
Fix the error: Properties should not be accessed directly in front order view