### PR TITLE
Update curl opt sslversion to TLS v1.2

### DIFF
--- a/includes/class-wc-cielo-api.php
+++ b/includes/class-wc-cielo-api.php
@@ -89,7 +89,7 @@ class WC_Cielo_API {
 	 */
 	public function curl_settings( $handle, $r, $url ) {
 		if ( isset( $r['sslcertificates'] ) && $this->get_certificate() === $r['sslcertificates'] && $this->get_api_url() === $url ) {
-			curl_setopt( $handle, CURLOPT_SSLVERSION, 4 );
+			curl_setopt( $handle, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2 );
 		}
 	}
 


### PR DESCRIPTION
Fiz uma alteração na versão do TLS de 1.0 para a v1.2, que é a mínima exigida pela documentação da Cielo: https://developercielo.github.io/faq/faq-api-3-0

> 10. É necessário algum protocolo de segurança para a utilização da API Cielo eCommerce
> É obrigatório o uso de TLS 1.2 na comunicação a API.
> 
> SSL,TLS 1.0 e 1.1 não são suportados. Integrações utilizando esses protocolos não poderão realizar transações.

Isso resolve a issue https://github.com/greguly/cielo-woocommerce/issues/74